### PR TITLE
Removed inline styling from the React root div

### DIFF
--- a/packages/inspire/ui/ReactRoot.js
+++ b/packages/inspire/ui/ReactRoot.js
@@ -230,7 +230,7 @@ export default class ReactRoot extends React.Component {
     const vViewFocus = this.props.vViewFocus;
     if (!vViewFocus || !this._rootContext) return null;
     return (
-      <div style={{ width: "100vw", height: "100vh" }}>
+      <div>
         <Valoscope
           {...uiComponentProps({
             name: "root", parentUIContext: this._rootContext, focus: vViewFocus,


### PR DESCRIPTION
This styling interferes with external CSS libraries as well as requires the developer to manually set project wrappers to negate the horizontal scrolling.